### PR TITLE
adds enercity-dev > lynqtech-dev compatibility mode

### DIFF
--- a/kustomize-lqt
+++ b/kustomize-lqt
@@ -60,6 +60,9 @@ sed -i '' -e 's/currentVersion/'"${DRONE_COMMIT_SHA}"'/g' $CONFIG_BASE/base/kust
 sed -i '' -e 's/serviceTag/'"generic-${DRONE_COMMIT_SHA}"'/g' $CONFIG_BASE/base/kustomization.yaml
 sed -i '' -e 's/initTag/'"generic-init-${DRONE_COMMIT_SHA}"'/g' $CONFIG_BASE/base/kustomization.yaml
 
+echo "Clients found: ${CLIENTS[*]}"
+echo "Environments to process: ${ENVIRONMENTS[*]}"
+
 for DIR in "${CLIENTS[@]}"
 do
   if [[ ${#ENVIRONMENTS[@]} == 1 ]]; then
@@ -82,7 +85,7 @@ do
     fi
 
     CLIENT=${DIR#"$FOLDER"}
-    echo "Processing k8s/$CLIENT/$ENVIRONMENT/$SERVICE/manifest-$TAG.yaml"
+    echo "Trying to process k8s/$CLIENT/$ENVIRONMENT/$SERVICE/manifest-$TAG.yaml"
     # compatibility mode, enercity-dev > lynqtech-dev, remove once all enercity-dev overlays have been migrated to lynqtech-dev
     if [ "$CLIENT" = "enercity" ] && [ "$ENVIRONMENT" = "dev" ]; then
       CLIENT="lynqtech"

--- a/kustomize-lqt
+++ b/kustomize-lqt
@@ -80,21 +80,17 @@ do
       ENVIRONMENT=${ENVIRONMENT//[0-9_.]/}
       echo "Updated environment variable from $old_environment to $ENVIRONMENT"
     fi
-    
+
     CLIENT=${DIR#"$FOLDER"}
-    BUILD_DIR=$DIR/$ENVIRONMENT/
-
-    # compatibility mode, remove if not used anymore
-    if [ "$CLIENT" = "dev" ] || [ "$CLIENT" = "stage" ] || [ "$CLIENT" = "migration" ] || [ "$CLIENT" = "prod" ]; then
-      if [ "$CLIENT" != $ENVIRONMENT ]; then
-        continue
-      fi
-      echo "*** No Tenant found - Compatibility Mode for enercity"
-      CLIENT="enercity"
-      BUILD_DIR=$DIR/
-    fi
-
     echo "Processing k8s/$CLIENT/$ENVIRONMENT/$SERVICE/manifest-$TAG.yaml"
+    # compatibility mode, enercity-dev > lynqtech-dev, remove once all enercity-dev overlays have been migrated to lynqtech-dev
+    if [ "$CLIENT" = "enercity" ] && [ "$ENVIRONMENT" = "dev" ]; then
+      CLIENT="lynqtech"
+      echo "Compatibility Mode, client: enercity >>> lynqtech"
+    fi
+    # compatibility mode, end
+
+    BUILD_DIR=$DIR/$ENVIRONMENT/
 
     if [ ! -d "$BUILD_DIR" ]; then
       echo "BUILD_DIR: $BUILD_DIR does not exist, skipping"


### PR DESCRIPTION
once merged, the envvar client for jenkins lynqtech-dev needs to be changed
old: enercity
new: lynqtech

should be handled by @thomaswiener 

how to test?
checkout devops-pipeline-sample-app, copy kustomize-lqt to home directory and execute:
`./kustomize-lqt devops-pipeline-sample-app k8s dev`

testcases change overlays:
- add empty folder lynqtech
- add copy enercity/dev to lynqtech/dev
- rm enercity/dev

verify manifest files in k8s folder